### PR TITLE
Remove netstandard warning

### DIFF
--- a/Reactor.OxygenFilter.MSBuild/Reactor.OxygenFilter.MSBuild.TargetFramework.props
+++ b/Reactor.OxygenFilter.MSBuild/Reactor.OxygenFilter.MSBuild.TargetFramework.props
@@ -12,11 +12,6 @@
     <UsingTask TaskName="Reobfuscate" AssemblyFile="$(TaskAssembly)" />
     <UsingTask TaskName="Deobfuscate" AssemblyFile="$(TaskAssembly)" />
 
-    <Target Name="WarnAboutTargetFramework" BeforeTargets="PrepareForBuild" Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
-        <!-- TODO link to docs explaining why netstandard is better -->
-        <Warning Text="Your project is not targetting netstandard2.1, you probably want to change that." File="$(MSBuildProjectFullPath)" />
-    </Target>
-
     <Target Name="LoadMappings">
         <LoadMappings GameVersion="$(GameVersion)" Mappings="$(Mappings)" />
     </Target>


### PR DESCRIPTION
Even though netstandard is better, you should not add a warning about that. Inexperienced users might think that their mod might break if they don't use netstandard, which is not true. Also the warning is annoying stop asking me to switch I won't I just want to use net framework why is that a problem
